### PR TITLE
Change %pkg_path% to %destination_path%

### DIFF
--- a/CrashPlanPROeClient.LANrev.recipe
+++ b/CrashPlanPROeClient.LANrev.recipe
@@ -27,7 +27,7 @@
                 <key>sdpackages_ampkgprops_path</key>
                 <string>%RECIPE_DIR%/%NAME%-Defaults.ampkgprops</string>
                 <key>source_payload_path</key>
-                <string>%pkg_path%</string>
+                <string>%destination_path%</string>
                 <key>import_pkg_to_servercenter</key>
                 <true/>
             </dict>


### PR DESCRIPTION
The recipe fails as `%pkg_path%` does not map to anything.