### PR TITLE
Import .app instead of .pkg

### DIFF
--- a/DbVisualizer/DbVisualizer.filewave.recipe
+++ b/DbVisualizer/DbVisualizer.filewave.recipe
@@ -10,8 +10,8 @@
 	<dict>
 		<key>NAME</key>
 		<string>DbVisualizer</string>
-        <key>fw_destination_root</key>
-        <string>/Applications/DbVisualizer.app</string>
+        	<key>fw_destination_root</key>
+        	<string>/Applications/DbVisualizer.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
@@ -41,10 +41,16 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %fw_app_version%</string>
 				<key>fw_import_source</key>
-                                <string>%pkg_path%</string>
+                                <string>%RECIPE_CACHE_DIR%/DbVisualizer/Applications/DbVisualizer.app</string>
+				<key>fw_app_bundle_id</key>
+				<string>%fw_app_bundle_id%</string>
+				<key>fw_app_version</key>
+				<string>%version%</string>
+				<key>fw_destination_root</key>
+				<string>%fw_destination_root%</string>
 			</dict>
 			<key>Comment</key>
-			<string>Import the latest DbVisualizer pkg into FileWave</string>
+			<string>Import the latest DbVisualizer app into FileWave</string>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>
 		</dict>


### PR DESCRIPTION
Import .app instead of .pkg as you can have a better fileset control via FileWave. Using a .pkg will leave the .app on the destination and FileWave will never know if the user removed it or not.