### PR TITLE
Remove trust info from two recipes

### DIFF
--- a/Firefox/Firefox.filewave.recipe
+++ b/Firefox/Firefox.filewave.recipe
@@ -15,32 +15,6 @@
 	<string>0.5.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.pkg.Firefox_EN</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.autopkg.jessepeterson.download.dockutil</key>
-			<dict>
-				<key>git_hash</key>
-				<string>09a528e3aabe2c236432b259ca0d3a2524a53eac</string>
-				<key>path</key>
-				<string>/Users/Shared/Autopkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes/dockutil/dockutil.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>d913fa911ebfa53c976f07af29a9b59255818338ad670de11aa8399e960e639b</string>
-			</dict>
-			<key>com.github.autopkg.jessepeterson.pkg.dockutil</key>
-			<dict>
-				<key>git_hash</key>
-				<string>9ba13556e9192fd21a950799dae3fb75e016fe68</string>
-				<key>path</key>
-				<string>/Users/Shared/Autopkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes/dockutil/dockutil.pkg.recipe</string>
-				<key>sha256_hash</key>
-				<string>c01d4b52448e24b029091ba83dce9873ff496f5f2d25423eb9c96caa54ba4c57</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/dockutil/dockutil.filewave.recipe
+++ b/dockutil/dockutil.filewave.recipe
@@ -15,32 +15,6 @@
 	<string>0.5.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.jessepeterson.pkg.dockutil</string>
-	<key>ParentRecipeTrustInfo</key>
-	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
-		<dict>
-			<key>com.github.autopkg.jessepeterson.download.dockutil</key>
-			<dict>
-				<key>git_hash</key>
-				<string>09a528e3aabe2c236432b259ca0d3a2524a53eac</string>
-				<key>path</key>
-				<string>/Users/Shared/Autopkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes/dockutil/dockutil.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>d913fa911ebfa53c976f07af29a9b59255818338ad670de11aa8399e960e639b</string>
-			</dict>
-			<key>com.github.autopkg.jessepeterson.pkg.dockutil</key>
-			<dict>
-				<key>git_hash</key>
-				<string>9ba13556e9192fd21a950799dae3fb75e016fe68</string>
-				<key>path</key>
-				<string>/Users/Shared/Autopkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes/dockutil/dockutil.pkg.recipe</string>
-				<key>sha256_hash</key>
-				<string>c01d4b52448e24b029091ba83dce9873ff496f5f2d25423eb9c96caa54ba4c57</string>
-			</dict>
-		</dict>
-	</dict>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Trust info belongs in local recipe overrides, not in public recipes.