### PR TITLE
Change parent recipe for cgerke-recipes deprecation

### DIFF
--- a/AbsoluteRecipes/GoogleDrive.Absolute.recipe
+++ b/AbsoluteRecipes/GoogleDrive.Absolute.recipe
@@ -12,7 +12,7 @@
         <string>GoogleDrive</string>
     </dict>
     <key>ParentRecipe</key>
-    <string>com.github.autopkg.cgerke-recipes.pkg.GoogleDrive</string>
+    <string>com.github.homebysix.pkg.GoogleDrive</string>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
     <key>Process</key>

--- a/LANrevRecipes/GoogleDrive.LANrev.recipe
+++ b/LANrevRecipes/GoogleDrive.LANrev.recipe
@@ -12,7 +12,7 @@
         <string>GoogleDrive</string>
     </dict>
     <key>ParentRecipe</key>
-    <string>com.github.autopkg.cgerke-recipes.pkg.GoogleDrive</string>
+    <string>com.github.homebysix.pkg.GoogleDrive</string>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
     <key>Process</key>


### PR DESCRIPTION
The parent recipe has been copied to homebysix-recipes in order to prepare for cgerke-recipes deprecation. For details, see: autopkg/cgerke-recipes#37

