### PR TITLE
Deprecate AdobeDNGConverter recipe

### DIFF
--- a/LANrevRecipes/AdobeDNGConverter.LANrev.recipe
+++ b/LANrevRecipes/AdobeDNGConverter.LANrev.recipe
@@ -14,9 +14,18 @@
     <key>ParentRecipe</key>
     <string>com.github.sheagcraig.pkg.AdobeDNGConverter</string>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>AdobeDNGConverter is behind a sign-in page as of May 2021. This recipe will no longer be updated, and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>com.github.jbaker10.LANrevImporter/LANrevImporter</string>


### PR DESCRIPTION
Download has been moved behind a sign-in page. (https://github.com/autopkg/sheagcraig-recipes/issues/65)