### PR TITLE
Adjust parent for Slack LANrev recipe

### DIFF
--- a/LANrevRecipes/Slack.LANrev.recipe
+++ b/LANrevRecipes/Slack.LANrev.recipe
@@ -12,7 +12,7 @@
         <string>Slack</string>
     </dict>
     <key>ParentRecipe</key>
-    <string>com.github.killahquam.pkg.slack</string>
+    <string>com.github.rtrouton.pkg.SlackUniversal</string>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
     <key>Process</key>


### PR DESCRIPTION
The recipes in killahquam-recipes have been deprecated and will be removed soon. (See https://github.com/autopkg/killahquam-recipes/issues/28 for details.)

This pull request adjusts the parent for a recipe that references killahquam-recipes. The parent has been changed to an actively maintained recipe in another repo.