### PR TITLE
Resolve merge conflict in AdobeReader.filewave

### DIFF
--- a/AdobeReader/AdobeReader.filewave.recipe
+++ b/AdobeReader/AdobeReader.filewave.recipe
@@ -27,11 +27,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %LANGUAGE% - %version%</string>
 				<key>fw_import_source</key>
-<<<<<<< HEAD:AdobeReader/AdobeReader.filewave.recipe
-                                <string>%pkg_path%</string>
-=======
 				<string>%pkg_path%</string>
->>>>>>> 585f4e34de634d2d690cff02caa81a8a8300d8e3:AdobeReaderDC/AdobeReaderDC.filewave.recipe
 				<key>fw_app_version</key>
 				<string>%version%</string>
 			</dict>


### PR DESCRIPTION
This conflict was created in 5a9913c.

Fixes parsing error in this recipe that will appear to all who have the repo in their AutoPkg setup:

```
Warning: Unable to parse seansgm-recipes/AdobeReader/AdobeReader.filewave.recipe as plist: not well-formed (invalid token): line 30, column 1
```